### PR TITLE
(fix) for latest nmcli v1.0.6

### DIFF
--- a/proxydriver.sh
+++ b/proxydriver.sh
@@ -48,10 +48,10 @@ then
 	if type -P nmcli &>/dev/null
 	then
 		# retrieve connection/vpn name
-		networkID=`nmcli -t -f name,devices,vpn con status | \
+		networkID=`nmcli -t -f name,device,type con show | \
 			awk -F':' "BEGIN { device=\"$1\"; event=\"$2\" } \
-				event == \"up\" && \\$2 == device && \\$3 == \"no\" { print \\$1 } \
-				event == \"vpn-up\" && \\$3 == \"yes\" { print \"vpn_\" \\$1 }"`
+				event == \"up\" && \\$2 == device && \\$3 != \"vpn\" { print \\$1 } \
+				event == \"vpn-up\" && \\$3 == \"vpn\" { print \"vpn_\" \\$1 }"`
 	else
 		# try ESSID if nmcli is not installed
 		logger -p user.notice -t $log_tag "nmcli not detected, will use essid"


### PR DESCRIPTION
Current version of nmcli doesn't support `connection status` or the field `vpn`.
